### PR TITLE
Add SHA hash to all images, CSS and JS files.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
         paths: ['src/static/css']
         }
        ,files: {
-        'src/static/css/global.1.3.0.css': ['src/_includes/less/global.less'],
+        'src/static/css/global.css': ['src/_includes/less/global.less'],
         'src/_includes/css/preload.css': ['src/_includes/less/preload.less']
         }
       }
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
        ,paths: ['src/static/css']
         }
        ,files: {
-        'src/static/css/global.1.3.0.css': ['src/_includes/less/global.less'],
+        'src/static/css/global.css': ['src/_includes/less/global.less'],
         'src/_includes/css/preload.css': ['src/_includes/less/preload.less']
         }
       }
@@ -211,6 +211,26 @@ module.exports = function(grunt) {
     }
   }
 
+ ,hashres: {
+    options: {
+      encoding: 'utf8',
+      fileNameFormat: '${name}.${hash}.${ext}',
+      renameFiles: true
+    },
+    image: {
+      src: ['<%= grunt.config.get("dest") %>/media/**/*.{png,jpg,gif,svg}','<%= grunt.config.get("dest") %>/static/**/*.{png,jpg,gif,svg}'],
+      dest: '<%= grunt.config.get("dest") %>/**/*.{html,css}',
+    },
+    css: {
+      src: ['<%= grunt.config.get("dest") %>/static/css/**/*.css'],
+      dest: '<%= grunt.config.get("dest") %>/**/*.html',
+    },
+    js: {
+      src: ['<%= grunt.config.get("dest") %>/static/js/**/*.js'],
+      dest: '<%= grunt.config.get("dest") %>/**/*.html',
+    }
+  }
+
   });
 
   // Tasks
@@ -227,7 +247,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-config');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-notify');
-  grunt.loadNpmTasks("grunt-modernizr");
+  grunt.loadNpmTasks('grunt-modernizr');
+  grunt.loadNpmTasks('grunt-hashres');
   //grunt.loadNpmTasks('grunt-autoprefixer');
 
   // Options
@@ -237,6 +258,6 @@ module.exports = function(grunt) {
   grunt.registerTask('optim', ['imagemin']);
   grunt.registerTask('dev', ['config:dev', 'clean', 'less:development', 'shell:jekyll_dev', 'copy']);
   grunt.registerTask('serve', ['express', 'watch']);
-  grunt.registerTask('stage', ['config:stage', 'clean', 'less:production', 'shell:jekyll_stage', 'copy', 'optim']);
-  grunt.registerTask('deploy', ['config:deploy', 'clean', 'less:production', 'shell:jekyll_deploy', 'copy', /*'modernizr',*/ 'optim']);
+  grunt.registerTask('stage', ['config:stage', 'clean', 'less:production', 'shell:jekyll_stage', 'copy', 'optim', 'hashres']);
+  grunt.registerTask('deploy', ['config:deploy', 'clean', 'less:production', 'shell:jekyll_deploy', 'copy', /*'modernizr',*/ 'optim', 'hashres']);
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function(grunt) {
           jQuery: true
         }
       },
-      src: ['gruntfile.js', '<%= grunt.config.get("dest") %>/static/js/*.js']
+      src: ['gruntfile.js', 'src/_includes/js/*.js']
     }
 
   // Optimise
@@ -211,25 +211,25 @@ module.exports = function(grunt) {
     }
   }
 
- ,hashres: {
-    options: {
-      encoding: 'utf8',
-      fileNameFormat: '${name}.${hash}.${ext}',
-      renameFiles: true
-    },
-    image: {
-      src: ['<%= grunt.config.get("dest") %>/media/**/*.{png,jpg,gif,svg}','<%= grunt.config.get("dest") %>/static/**/*.{png,jpg,gif,svg}'],
-      dest: '<%= grunt.config.get("dest") %>/**/*.{html,css}',
-    },
-    css: {
-      src: ['<%= grunt.config.get("dest") %>/static/css/**/*.css'],
-      dest: '<%= grunt.config.get("dest") %>/**/*.html',
-    },
-    js: {
-      src: ['<%= grunt.config.get("dest") %>/static/js/**/*.js'],
-      dest: '<%= grunt.config.get("dest") %>/**/*.html',
+   ,hashres: {
+      options: {
+        encoding: 'utf8',
+        fileNameFormat: '${name}.${hash}.${ext}',
+        renameFiles: true
+      },
+      image: {
+        src: ['<%= grunt.config.get("dest") %>/media/**/*.{png,jpg,gif,svg}','<%= grunt.config.get("dest") %>/static/**/*.{png,jpg,gif,svg}'],
+        dest: '<%= grunt.config.get("dest") %>/**/*.{html,css}',
+      },
+      css: {
+        src: ['<%= grunt.config.get("dest") %>/static/css/**/*.css'],
+        dest: '<%= grunt.config.get("dest") %>/**/*.html',
+      },
+      js: {
+        src: ['<%= grunt.config.get("dest") %>/static/js/**/*.js'],
+        dest: '<%= grunt.config.get("dest") %>/**/*.html',
+      }
     }
-  }
 
   });
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-notify": "0.2.x",
     "grunt-autoprefixer": "0.7.x",
     "grunt-modernizr": "0.5.x",
-    "grunt-contrib-imagemin": "0.7.x"
+    "grunt-contrib-imagemin": "0.7.x",
+    "grunt-hashres": "0.4.x"
   }
 }

--- a/src/_includes/templates/css.html
+++ b/src/_includes/templates/css.html
@@ -1,5 +1,5 @@
 <!--  CSS  -->
 
-<link rel="stylesheet" media="screen" href="{{ site.url }}/static/css/global.1.3.0.css">
+<link rel="stylesheet" media="screen" href="{{ site.url }}/static/css/global.css">
 {% if page.stylesheet %}<link rel="stylesheet" media="screen" href="{{ site.url }}/static/css/{{ page.stylesheet }}.css">
 {% endif %}

--- a/src/_includes/templates/javascript_body.html
+++ b/src/_includes/templates/javascript_body.html
@@ -2,6 +2,6 @@
 
 <!--  Global/Section JavaScript  -->
 
-<script src="{{ site.static }}/js/global.1.3.0.js" async></script>
+<script src="{{ site.static }}/js/global.js" async></script>
 
 {% include templates/analytics.html %}

--- a/src/static/js/global.js
+++ b/src/static/js/global.js
@@ -1,0 +1,24 @@
+---
+---
+
+{% include bower_components/jquery/dist/jquery.min.js %}
+
+/**
+ * Responsive Navigation
+ */
+(function ( $ ) {
+
+  $(document).ready(function() {
+
+
+    $("#js-menu__icon").click(function () {
+      $("#js-nav__main").toggleClass("is-active");
+    });
+
+  });
+
+}(jQuery));
+
+{% include js/jquery.svgfallback.js %}
+
+{% include bower_components/FitVids/jquery.fitvids.js %}


### PR DESCRIPTION
This will allow us to cache files for longer. Reduce page load times for repeat views.

The task also replaces the file names in the html/css files to automate the cache busting.

No input from the content updater is needed :sunglasses:
